### PR TITLE
Swift Package Manager version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ fastlane/test_output
 *.swp
 
 Pods/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     targets: [
         .target(
             name: "KWDrawerController",
-            path: "KWDrawerController/DrawerController"
+            path: "DrawerController"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ let package = Package(
     products: [
         .library(name: "KWDrawerController", targets: ["KWDrawerController"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .from("5.0.0"))
+    ],
     targets: [
         .target(
             name: "KWDrawerController",

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .exact( "5.0.0"))
-//        .package(name: "RxCocoa", url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,14 @@ import PackageDescription
 
 let package = Package(
     name: "KWDrawerController",
+    platforms: [
+        .iOS(.v10)
+    ],
     products: [
         .library(name: "KWDrawerController", targets: ["KWDrawerController"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", exact: "5.0.0")
     ],
     targets: [
         .target(
@@ -16,4 +19,3 @@ let package = Package(
         )
     ]
 )
-

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
@@ -10,12 +10,13 @@ let package = Package(
         .library(name: "KWDrawerController", targets: ["KWDrawerController"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", exact: "5.0.0")
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .exact( "5.0.0"))
+//        .package(name: "RxCocoa", url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0")
     ],
     targets: [
         .target(
             name: "KWDrawerController",
-            dependencies: ["RxSwift"],
+            dependencies: [ "RxSwift", "RxCocoa" ],
             path: "DrawerController"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "KWDrawController",
+    products: [
+        .library(name: "KWDrawController", targets: ["KWDrawController"])
+    ],
+    targets: [
+        .target(
+            name: "KWDrawController",
+            path: "KWDrawController/DrawController"
+        )
+    ]
+)
+

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KWDrawerController", targets: ["KWDrawerController"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .exact( "5.0.0"))
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .exact( "5.1.3"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     targets: [
         .target(
             name: "KWDrawerController",
+            dependencies: ["RxSwift"],
             path: "DrawerController"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -2,14 +2,14 @@
 import PackageDescription
 
 let package = Package(
-    name: "KWDrawController",
+    name: "KWDrawerController",
     products: [
-        .library(name: "KWDrawController", targets: ["KWDrawController"])
+        .library(name: "KWDrawerController", targets: ["KWDrawerController"])
     ],
     targets: [
         .target(
-            name: "KWDrawController",
-            path: "KWDrawController/DrawController"
+            name: "KWDrawerController",
+            path: "KWDrawerController/DrawerController"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "KWDrawerController", targets: ["KWDrawerController"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .from("5.0.0"))
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Added Swift Package manager with package dependencies dating back to 2020

You can verify the Package.swift builds correctly using:
`swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios14.0-simulator"`